### PR TITLE
Fix density collection for shooting from EQ points + make restarts more versatile

### DIFF
--- a/aimmd/base/rcmodel.py
+++ b/aimmd/base/rcmodel.py
@@ -694,17 +694,18 @@ class TrajectoryDensityCollector:
         self._counts[self._fill_pointer:self._fill_pointer+tra_len] = counts_arr
         self._fill_pointer += tra_len
 
-    def append(self, tra_descriptors, multiplicity=1):
+    def append(self, tra_descriptors, multiplicity=1.):
         """
         Append trajectory descriptors to internal cache.
 
         Parameters:
         -----------
         tra_descriptors - numpy.array
-        multiplicity - int (default=1), weight for trajectory in ensemble,
-                       can also be 1d numpy.array with len=len(tra_descriptors)
+        multiplicity - float (default=1.), weight for trajectory in ensemble,
+                       can also be 1d np.array with len=len(tra_descriptors),
+                       i.e. one weight per configuration
         """
-        if isinstance(multiplicity, (int, np.integer)):
+        if isinstance(multiplicity, (int, np.integer, float, np.floating)):
             multiplicity = np.full((tra_descriptors.shape[0]), multiplicity)
         self._append(tra_descriptors, multiplicity)
 
@@ -725,8 +726,11 @@ class TrajectoryDensityCollector:
         model - aimmd.base.RCModel predicting commitment probabilities
         trajectories - iterator/iterable of trajectories to evaluate
         counts - None or list of weights for the trajectories,
-                 i.e. we will add every trajectory count times to the histo,
-                 if None, every trajectory is added once
+                 i.e. we will add every trajectory with weight=counts,
+                 if None, every trajectory has equal weight,
+                 can also be a list of np.arrays (each of the same lenght as
+                 the corresponding trajectory), i.e. supports different weights
+                 per configuration.
 
         """
         len_before = self._fill_pointer
@@ -764,8 +768,11 @@ class TrajectoryDensityCollector:
         model - aimmd.base.RCModel predicting commitment probabilities
         trajectories - iterator/iterable of trajectories to evaluate
         counts - None or list of weights for the trajectories,
-                 i.e. we will add every trajectory count times to the histo,
-                 if None, every trajectory is added once
+                 i.e. we will add every trajectory with weight=counts,
+                 if None, every trajectory has equal weight,
+                 can also be a list of np.arrays (each of the same lenght as
+                 the corresponding trajectory), i.e. supports different weights
+                 per configuration.
 
         """
         # add descriptors to self

--- a/aimmd/base/rcmodel.py
+++ b/aimmd/base/rcmodel.py
@@ -519,8 +519,11 @@ class TrajectoryDensityCollector:
             # create cache, also replaces self._descriptors
             self._create_h5py_cache(val)
             self._cache_file = val
-            self._fill_pointer = 0  # reset fill pointer so we can use append
-            self.append(tra_descriptors=descriptors, multiplicity=counts)
+            if self._fill_pointer > 0:
+                # append only if there is something to append
+                # (otherwise we would create the h5py dsets with descriptor_dim=0
+                self._fill_pointer = 0  # reset fill pointer so we can use append
+                self.append(tra_descriptors=descriptors, multiplicity=counts)
 
     def _create_h5py_cache(self, cache_file, copy_from=None):
         # the next line looks weird, but ensures the user can pass either

--- a/aimmd/base/rcmodel.py
+++ b/aimmd/base/rcmodel.py
@@ -842,13 +842,19 @@ class TrajectoryDensityCollector:
         """
         dens = self.get_counts(probabilities)
         norm = np.sum(self.density_histogram)
+        if norm == 0:
+            return np.ones_like(dens)  # if we dont have any density yet
         with np.errstate(divide="ignore"):
             # ignore errors through division by zero
             factor = norm / dens
         # and replace all infs by large (but finite) values in the array
         # TODO: Do we want to use the largest finite value occuring in array instead?
         #       Currently we just use the numpy default (a "very large number")
-        factor = np.nan_to_num(factor)
+        #factor = np.nan_to_num(factor)
+        # np.nan_to_num uses 1.797e308 to replace infs when using float64
+        # (but we use something much smaller because we dont want to have
+        #  overflows when multiplying it in the selection probability)
+        factor[factor == np.inf] = 1e100
         return factor
 
 

--- a/aimmd/base/rcmodel.py
+++ b/aimmd/base/rcmodel.py
@@ -833,6 +833,17 @@ class TrajectoryDensityCollector:
         """
         dens = self.get_counts(probabilities)
         norm = np.sum(self.density_histogram)
+        # NOTE: since allow for weights (instead of counts) to be added to the histogram
+        #       we must make sure that if norm << n_bins we still get a density
+        #       determined by the histogram instead of getting a uniform density always
+        #        because 1/n_bin dominates dens/norm
+        # the easiest (quick fix) is to just multiply both norm and dens by the number of
+        # points in the cache, such that we make sure that if we have 1000 points over which
+        # we calculate the density correction we will get norm=1000 again
+        n_points = self._fill_pointer  # number of points in cache
+        # scale both norm and dens by the same fact
+        norm *= n_points / norm   # == n_points always
+        dens *= n_points / norm
         return (norm + self._n_allowed_bins) / (dens + 1)
 
 

--- a/aimmd/base/rcmodel.py
+++ b/aimmd/base/rcmodel.py
@@ -648,7 +648,7 @@ class TrajectoryDensityCollector:
                                             name="counts",
                                             shape=(add,),
                                             maxshape=(None,),
-                                            dtype="i8",
+                                            dtype="f",
                                                       )
         else:
             # possibly extend existing datasets

--- a/aimmd/distributed/pathsampling.py
+++ b/aimmd/distributed/pathsampling.py
@@ -797,7 +797,7 @@ class Brain:
             # those first.
             # NOTE: if we have more unfinished steps than we are requested to
             #       do steps, we will still have unfinished steps afterwards
-            n_incomplete = sum([s.contains_unfinished_step
+            n_incomplete = sum([s.contains_partial_step
                                 for s in self.samplers],
                                 )
             # how many samplers we need to start fresh to get to n_steps

--- a/aimmd/distributed/spselectors.py
+++ b/aimmd/distributed/spselectors.py
@@ -351,7 +351,7 @@ class RCModelSPSelectorFromEQ(RCModelSPSelector):
                                                         model=model)
                                             for t in self.trajectories + [trajectory])
                                           )
-        biases_for_SP_ensemble = all_biases[:-1]
+        biases_for_SP_ensemble = np.concatenate(all_biases[:-1], axis=0)
         biases_for_new_traj = all_biases[-1]
         Z_bias = np.sum(biases_for_SP_ensemble)
         return Z_bias / np.sum(biases_for_new_traj)


### PR DESCRIPTION
Fix for density collection, such that it works properly for non integer counts in each bin, i.e. when used with shooting points with known EQ weights.

Also make restarts a bit more versatile by enabling the user to decide if/when the unfinished steps should be continued and finished.

TODO:
- [x] update docstrings (and parameter names?) for density collection to reflect that not only integer counts work
- [ ] think about saving the density collection separate from the RCModels to make the storage smaller?!