### PR TITLE
WIP: make aimmd.distributed filepaths relative

### DIFF
--- a/aimmd/distributed/committors.py
+++ b/aimmd/distributed/committors.py
@@ -194,7 +194,7 @@ class CommittorSimulation:
             return val
 
         # TODO: should some of these be properties?
-        self.workdir = os.path.abspath(workdir)
+        self.workdir = os.path.relpath(workdir)
         self.starting_configurations = starting_configurations
         self.states = states
         self.engine_cls = ensure_list(val=engine_cls,

--- a/aimmd/distributed/pathsampling.py
+++ b/aimmd/distributed/pathsampling.py
@@ -379,7 +379,7 @@ class Brain:
         #       mover, but the big drawback of assuming we only ever want to do
         #       *T*PS with this class
         self.model = model
-        self.workdir = os.path.abspath(workdir)
+        self.workdir = os.path.relpath(workdir)
         self.storage = storage
         self.tasks = tasks
         # TODO: sanity check?
@@ -940,7 +940,7 @@ class PathChainSampler:
     def __init__(self, workdir: str, mcstep_collection, modelstore,
                  sampler_idx: int, movers: list[PathMover],
                  mover_weights: typing.Optional["list[float]"] = None):
-        self.workdir = os.path.abspath(workdir)
+        self.workdir = os.path.relpath(workdir)
         self.mcstep_collection = mcstep_collection
         self.modelstore = modelstore
         self.sampler_idx = sampler_idx


### PR DESCRIPTION
Use relative filepaths in `aimmd.distributed` to make moving storages and TPS simulations more straightforward.

Fixes #7