### PR TITLE
Distributed model sanity checks

### DIFF
--- a/aimmd/distributed/committors.py
+++ b/aimmd/distributed/committors.py
@@ -194,7 +194,7 @@ class CommittorSimulation:
             return val
 
         # TODO: should some of these be properties?
-        self.workdir = os.path.abspath(workdir)
+        self.workdir = os.path.relpath(workdir)
         self.starting_configurations = starting_configurations
         self.states = states
         self.engine_cls = ensure_list(val=engine_cls,

--- a/aimmd/distributed/pathsampling.py
+++ b/aimmd/distributed/pathsampling.py
@@ -1100,12 +1100,12 @@ class PathChainSampler:
         all_steps_by_time = {}
         for stepdir in all_possible_stepdirs:
             if os.path.isdir(stepdir):
-                try:
+                # the step is only done if we have an MCStep pickle file
+                if os.path.isfile(os.path.join(stepdir,
+                                               MCstep.default_savename,
+                                               )
+                                  ):
                     s = MCstep.load(directory=stepdir)
-                except FileNotFoundError:
-                    # this step is (probably) not done yet
-                    pass
-                else:
                     mtime = os.path.getmtime(os.path.join(stepdir,
                                                           s.default_savename)
                                              )

--- a/aimmd/distributed/pathsampling.py
+++ b/aimmd/distributed/pathsampling.py
@@ -491,17 +491,21 @@ class Brain:
         #       -> If it is None we set it to storage and warn about it
         #       -> If it is set to a value we dont (re)set it but warn if that
         #          value is not storage?
-        if not (model.density_collector.cache_file is storage.file):
-            # Note: check for the h5-file and not the storage class object
+        if not ((model.density_collector.cache_file is storage)
+                or (model.density_collector.cache_file is storage.file)
+                ):
+            # Note: check for the h5-file and the storage class object,
+            #       it could be either of the two
             if model.density_collector.cache_file is None:
                 warn_str = "`model.density_collector.cache_file` is not set."
             else:
                 warn_str = "`model.density_collector.cache_file` is not set to"
                 warn_str += "`storage`."
-            logger.warning("%s If this was not intended it is recommended to "
-                           "set `model.density_collector.cache_file` to the "
-                           "same value as `storage` to avoid unedxpected "
-                           "side-effects."
+            logger.warning(("%s If this was not intended it is recommended to "
+                            "set `model.density_collector.cache_file` to the "
+                            "same value as `storage` to avoid unexpected "
+                            "side-effects."
+                            ), warn_str,
                            )
             any_warned = True
         # If we warned about model.descriptor_transform, model.states or

--- a/aimmd/distributed/pathsampling.py
+++ b/aimmd/distributed/pathsampling.py
@@ -1130,12 +1130,8 @@ class PathChainSampler:
             if make_symlink:
                 fd = os.open(self.workdir, os.O_RDONLY)
                 os.symlink(os.path.relpath(step.directory, self.workdir),
-                           os.path.relpath(os.path.join(
-                                                self.workdir,
-                                                f"{self.mcstate_name_prefix}"
-                                                + f"{self._stepnum}"
-                                                        ), self.workdir),
-                            dir_fd=fd,
+                           f"{self.mcstate_name_prefix}{self._stepnum}",
+                           dir_fd=fd,
                            )
                 os.close(fd)
         else:
@@ -1145,12 +1141,12 @@ class PathChainSampler:
                 self._accepts.append(0)
             if make_symlink:
                 # link the old state as current/accepted state
-                os.symlink(instep.directory,
-                           os.path.join(self.workdir,
-                                        f"{self.mcstate_name_prefix}"
-                                        + f"{self._stepnum}"
-                                        )
+                fd = os.open(self.workdir, os.O_RDONLY)
+                os.symlink(os.path.relpath(instep.directory, self.workdir),
+                           f"{self.mcstate_name_prefix}{self._stepnum}",
+                           dir_fd=fd,
                            )
+                os.close(fd)
 
     async def finish_step(self, model):
         # _run_step increases the _stepnum, so we are looking for the next step

--- a/aimmd/distributed/pathsampling.py
+++ b/aimmd/distributed/pathsampling.py
@@ -1128,7 +1128,7 @@ class PathChainSampler:
                 self._accepts.append(1)
             self.current_step = step
             if make_symlink:
-                fd = os.open(self.workdir)
+                fd = os.open(self.workdir, os.O_RDONLY)
                 os.symlink(os.path.relpath(step.directory, self.workdir),
                            os.path.relpath(os.path.join(
                                                 self.workdir,

--- a/aimmd/distributed/pathsampling.py
+++ b/aimmd/distributed/pathsampling.py
@@ -475,7 +475,7 @@ class Brain:
                            ".TrajectoryFunctionwrapper subclasses."
                            )
             any_warned = True
-        if not all(isinstance(s, TrajectoryFunctionWrapper)
+        elif not all(isinstance(s, TrajectoryFunctionWrapper)
                    for s in model.states
                    ):
             logger.warning("Not all model.states are `asyncmd.trajectory."

--- a/aimmd/distributed/pathsampling.py
+++ b/aimmd/distributed/pathsampling.py
@@ -1128,11 +1128,13 @@ class PathChainSampler:
                 self._accepts.append(1)
             self.current_step = step
             if make_symlink:
-                os.symlink(step.directory, os.path.join(
+                os.symlink(os.path.relpath(step.directory, self.workdir),
+                           os.path.relpath(os.path.join(
                                                 self.workdir,
                                                 f"{self.mcstate_name_prefix}"
                                                 + f"{self._stepnum}"
-                                                        )
+                                                        ), self.workdir),
+                            dir_fd=self.workdir,
                            )
         else:
             if not is_step_zero:

--- a/aimmd/distributed/pathsampling.py
+++ b/aimmd/distributed/pathsampling.py
@@ -379,7 +379,7 @@ class Brain:
         #       place?! Has the benefit that we dont need to pass it to every
         #       mover, but the big drawback of assuming we only ever want to do
         #       *T*PS with this class
-        self._check_model(model=model)
+        self._check_model(model=model, storage=storage)
         self.model = model
         self.workdir = os.path.relpath(workdir)
         self.storage = storage
@@ -436,13 +436,13 @@ class Brain:
                                       )
                          ]
 
-    def _check_model(self, model):
+    def _check_model(self, model, storage):
         """Basic sanity checks for model before TPS simulation.
 
         Checks:
             - that the model has a descriptor transform and if it is async
             - that the model has states and if they are callable and async
-            - the model.density_collector.cache file is set to self.storage
+            - the model.density_collector.cache file is set to storage
         """
         # if we warn about anything not beeing set as expected we should also
         # tell the user about model.ee_params (which will then most likely also
@@ -487,20 +487,20 @@ class Brain:
             any_warned = True
         # density collector cache file
         # TODO: what is the best thing to do here?
-        #       check if it is set to the 'correct' file (i.e. self.storage),
-        #       -> If it is None we set it to self.storage and warn about it
+        #       check if it is set to the 'correct' file (i.e. storage),
+        #       -> If it is None we set it to storage and warn about it
         #       -> If it is set to a value we dont (re)set it but warn if that
-        #          value is not self.storage?
-        if not (model.density_collector.cache_file is self.storage.file):
+        #          value is not storage?
+        if not (model.density_collector.cache_file is storage.file):
             # Note: check for the h5-file and not the storage class object
             if model.density_collector.cache_file is None:
                 warn_str = "`model.density_collector.cache_file` is not set."
             else:
                 warn_str = "`model.density_collector.cache_file` is not set to"
-                warn_str += "`self.storage`."
+                warn_str += "`storage`."
             logger.warning("%s If this was not intended it is recommended to "
                            "set `model.density_collector.cache_file` to the "
-                           "same value as `self.storage` to avoid unedxpected "
+                           "same value as `storage` to avoid unedxpected "
                            "side-effects."
                            )
             any_warned = True

--- a/aimmd/distributed/pathsampling.py
+++ b/aimmd/distributed/pathsampling.py
@@ -379,7 +379,7 @@ class Brain:
         #       mover, but the big drawback of assuming we only ever want to do
         #       *T*PS with this class
         self.model = model
-        self.workdir = os.path.abspath(workdir)
+        self.workdir = os.path.relpath(workdir)
         self.storage = storage
         self.tasks = tasks
         # TODO: sanity check?
@@ -940,7 +940,7 @@ class PathChainSampler:
     def __init__(self, workdir: str, mcstep_collection, modelstore,
                  sampler_idx: int, movers: list[PathMover],
                  mover_weights: typing.Optional["list[float]"] = None):
-        self.workdir = os.path.abspath(workdir)
+        self.workdir = os.path.relpath(workdir)
         self.mcstep_collection = mcstep_collection
         self.modelstore = modelstore
         self.sampler_idx = sampler_idx

--- a/aimmd/distributed/pathsampling.py
+++ b/aimmd/distributed/pathsampling.py
@@ -469,9 +469,9 @@ class Brain:
         # states check (not so important, in practice we only infer the number
         #               of outputs for the model from the number of states)
         if model.states is None:
-            logger.warning("model.states is not set. This might lead to "
+            logger.warning("model.states is not set. This will lead to "
                            "unexpected behavior and it is recommended to set "
-                           "the states to `asyncmd.trakectory.functionwrapper."
+                           "the states to `asyncmd.trajectory.functionwrapper."
                            ".TrajectoryFunctionwrapper subclasses."
                            )
             any_warned = True

--- a/aimmd/distributed/pathsampling.py
+++ b/aimmd/distributed/pathsampling.py
@@ -1128,14 +1128,16 @@ class PathChainSampler:
                 self._accepts.append(1)
             self.current_step = step
             if make_symlink:
+                fd = os.open(self.workdir)
                 os.symlink(os.path.relpath(step.directory, self.workdir),
                            os.path.relpath(os.path.join(
                                                 self.workdir,
                                                 f"{self.mcstate_name_prefix}"
                                                 + f"{self._stepnum}"
                                                         ), self.workdir),
-                            dir_fd=self.workdir,
+                            dir_fd=fd,
                            )
+                os.close(fd)
         else:
             if not is_step_zero:
                 # we should never have a zeroth step that is not accepted, but


### PR DESCRIPTION
Some basic sanity checks for RCModels before starting a `aimmd.distributed` TPS simulation.

Builds in #9 and should be merged after that.
Addresses part of #6