### PR TITLE
Fix density collection

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,12 +76,30 @@ else:
     # all the subfolders of the project root
     include_dirs = ['.', numpy.get_include(), 'm']
 
-CY_EXTS = [Extension('aimmd.coords._symmetry',
-                     ['aimmd/coords/_symmetry.pyx'],
-                     include_dirs=include_dirs,
-                     extra_compile_args=["-O3", "-march=native", "-fopenmp"],
-                     extra_link_args=['-fopenmp'])
-           ]
+CY_EXTS = []
+if sys.platform.startswith("darwin"):
+    # we are on MacOS, so (probably) without openMP support,
+    # i.e. probably we are using ApplClang in gcc compatibility mode
+    # which is not really compatible to gcc as it is missing openMP (which is part of a gcc standard install)
+    CY_EXTS += [Extension('aimmd.coords._symmetry',
+                          ['aimmd/coords/_symmetry.pyx'],
+                          include_dirs=include_dirs,
+                          extra_compile_args=["-O3", "-march=native"],# "-fopenmp"],
+                          # for now just try sans openMP
+                          #extra_link_args=['-fopenmp'],
+                          )
+                ]
+else:
+    # lets just try with openmp and worst case is we have to deal with every other OS that comes up
+    # (for linux this works)
+    CY_EXTS += [Extension('aimmd.coords._symmetry',
+                          ['aimmd/coords/_symmetry.pyx'],
+                          include_dirs=include_dirs,
+                          extra_compile_args=["-O3", "-march=native", "-fopenmp"],
+                          extra_link_args=['-fopenmp'],
+                          )
+                ]
+
 
 # set linetrace macro if wanted
 if LINETRACE:


### PR DESCRIPTION
This reintroduces add-one-smoothing (or better: something similar) to the calculation of the density correction factor. Taking it out was not a problem for the distributed TPS because there the models see a more diverse set of shooting points and therefore are much less likely to have a prediction that results in zero counts in multiple density collection bins.

Fixes #11 (Thanks again for reporting!)

This also makes it possible to install on Macs by deactivating the openMP flag for the symmetry function compilation on Macs (which makes them slow(er) but I am assuming most people will just want to try stuff out on a Mac and run on a (Linux) workstation).