### PR TITLE
Update to new (v0.4.1) asyncmd version

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -24,7 +24,7 @@ jobs:
         pip install
         build
         --user
-    - name: Build a source tarball  # TODO: also build binary wheels with cibuildwheel!
+    - name: Build a source tarball  # TODO: also build binary wheels with cibuildwheel?!
       run: python3 -m build --sdist
     - name: Store the distribution packages
       uses: actions/upload-artifact@v4
@@ -76,7 +76,7 @@ jobs:
       with:
         inputs: >-
           ./dist/*.tar.gz
-          ./dist/*.whl
+        #  ./dist/*.whl  # we dont have a wheel build, so cant sign it here
     - name: Create GitHub Release
       env:
         GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         persist-credentials: false
-        lfs: true
+        lfs: false
     - name: Set up Python
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,6 +34,7 @@ jobs:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
           miniforge-version: latest
+          conda-remove-defaults: true
       - name: Install dependencies
         run: conda install pytorch
       - name: Install

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,10 @@ jobs:
       matrix:
         os: ["ubuntu-latest", # "macos-latest",
              ]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: [ # "3.10",  # remove py 3.10 because there is no mdtraj >= 1.11 for it
+                         "3.11", "3.12",
+                         #"3.13"  # openpathsampling does not work on py 3.13 ...
+                         ]
       fail-fast: false
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          lfs: true
+          lfs: false
       - uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - First release on PyPi
 
-[unreleased]: https://github.com/bio-phys/asyncmd/compare/v0.9.2.dev2...HEAD
-[0.9.1.dev2]: https://github.com/bio-phys/asyncmd/compare/v0.9.1.dev1...v0.9.1.dev2
+[unreleased]: https://github.com/bio-phys/aimmd/compare/v0.9.2.dev2...HEAD
+[0.9.1.dev2]: https://github.com/bio-phys/aimmd/compare/v0.9.1.dev1...v0.9.1.dev2
 [0.9.1.dev1]: https://github.com/bio-phys/aimmd/releases/tag/v0.9.1.dev1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- update aimmd.distributed (and the aimmd.Storage) to the new (v0.4.1) asyncmd
 - aimmd.distributed.committors: Remove hardcoded TRR trajectory type for output trajectories and instead use the same output file type as the engine.
 
 ## [0.9.1.dev2] - 2025-02-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- symmetry function compilation with cython now uses the correct types for mdtraj >= v1.11, require mdtraj >= v1.11 for installation.
 - update aimmd.distributed (and the aimmd.Storage) to the new (v0.4.1) asyncmd
 - aimmd.distributed.committors: Remove hardcoded TRR trajectory type for output trajectories and instead use the same output file type as the engine.
 

--- a/aimmd/coords/_symmetry.pyx
+++ b/aimmd/coords/_symmetry.pyx
@@ -19,14 +19,17 @@ cimport numpy as cnp
 from libc cimport math
 from cpython cimport list
 
-ctypedef cnp.float64_t float64_t
-ctypedef cnp.float32_t float32_t
-ctypedef cnp.int64_t int64_t
-ctypedef cnp.int32_t int32_t
-
 import numpy as np
 import mdtraj as md
 from cython.parallel import prange
+
+ctypedef cnp.float64_t float64_t
+ctypedef cnp.float32_t float32_t
+ctypedef cnp.int64_t int64_t
+#ctypedef cnp.int32_t int32_t # only needed for mdtraj version <=1.10
+# Note: see also below the type definition for pairs, intra_pairs, triples
+#       these are the return of mdtraj.select_pairs, which changed its return
+#       type with v1.11
 
 
 def sf(mdtra, mol_idxs, solv_idxs, g_parms, cutoff,
@@ -131,7 +134,10 @@ cdef cnp.ndarray[float64_t, ndim=2] symmetry_functions_by_solv(
 
     cdef float64_t r_c_fermi = cutoff - 1./math.sqrt(alpha_cutoff)
     cdef cnp.ndarray[int64_t, ndim=1] solv_in_cutoff_f
-    cdef cnp.ndarray[int32_t, ndim=2] pairs, intra_pairs, triples
+    # for mdtraj version >= 1.11
+    cdef cnp.ndarray[int64_t, ndim=2] pairs, intra_pairs, triples
+    # for mdtraj version <= 1.10
+    #cdef cnp.ndarray[int32_t, ndim=2] pairs, intra_pairs, triples
     cdef cnp.ndarray[float32_t, ndim=2] r_inter, r_intra, angles
 
     cdef float32_t Rij, Rik, Rjk, Aijk

--- a/aimmd/distributed/committors.py
+++ b/aimmd/distributed/committors.py
@@ -28,7 +28,7 @@ from asyncmd.trajectory.convert import (RandomVelocitiesFrameExtractor,
 from asyncmd.trajectory.propagate import (
                             MaxStepsReachedError,
                             ConditionalTrajectoryPropagator,
-                            construct_TP_from_plus_and_minus_traj_segments,
+                            construct_tp_from_plus_and_minus_traj_segments,
                                           )
 from asyncmd.utils import ensure_mdconfig_options
 
@@ -862,7 +862,7 @@ class CommittorSimulation:
             tra_out = os.path.join(step_dir,
                                    self.fname_transition_traj + f".{self.output_traj_type[conf_num]}")
             # TODO: we currently dont use the return, should call as _ = ... ?
-            path_traj = await construct_TP_from_plus_and_minus_traj_segments(
+            path_traj = await construct_tp_from_plus_and_minus_traj_segments(
                             minus_trajs=minus_trajs, minus_state=minus_state,
                             plus_trajs=plus_trajs, plus_state=plus_state,
                             state_funcs=self.states, tra_out=tra_out,

--- a/aimmd/distributed/pathmovers.py
+++ b/aimmd/distributed/pathmovers.py
@@ -34,7 +34,7 @@ from asyncmd.trajectory.propagate import (
                             ConditionalTrajectoryPropagator,
                             InPartsTrajectoryPropagator,
                             TrajectoryConcatenator,
-                            construct_TP_from_plus_and_minus_traj_segments,
+                            construct_tp_from_plus_and_minus_traj_segments,
                                           )
 from asyncmd.utils import ensure_mdconfig_options, nstout_from_mdconfig
 
@@ -600,7 +600,7 @@ class _TwoWayShootingPathMoverMixin:
                         + f"Forward trial reached state {fw_state}, "
                         + f"backward trial reached state {bw_state}.")
             tra_out = os.path.join(wdir, f"{self.path_filename}.{self.output_traj_type}")
-            path_traj = await construct_TP_from_plus_and_minus_traj_segments(
+            path_traj = await construct_tp_from_plus_and_minus_traj_segments(
                             minus_trajs=minus_trajs, minus_state=minus_state,
                             plus_trajs=plus_trajs, plus_state=plus_state,
                             state_funcs=self.states, tra_out=tra_out,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,10 +6,13 @@ build-backend = "setuptools.build_meta"
 name = "aimmd"
 version = "0.9.1dev2"
 dependencies = ["numpy >= 1.17", "cython",
-                "openpathsampling", "mdtraj", "networkx",
+                "openpathsampling",
+                # need mdtraj >= 1.11 to be able to type the mdtraj returns in _symmetry.pyx correctly
+                "mdtraj >= 1.11",
+                "networkx",
                 "h5py >= 3",
                 "mdanalysis",  # only needed for distributed examples
-                "asyncmd",
+                "asyncmd >= 0.4.1",
                 ]
 requires-python = ">=3.10"
 authors = [{ name = "Hendrik Jung", email = "hendrik.jung@biophys.mpg.de"}]


### PR DESCRIPTION
Use the freshly renamed functions and h5py cache logic asyncmd v0.4.1 introduced.
Also fix symmetry functions by requiring mdtraj >= v1.11.
Run tests only on python versions we know can work (i.e. remove py3.10 and py 3.13).